### PR TITLE
Update for Doctrine metadata mapping to make it overridable

### DIFF
--- a/src/Resources/config/doctrine/ProductVariant.orm.xml
+++ b/src/Resources/config/doctrine/ProductVariant.orm.xml
@@ -4,7 +4,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
 >
 
-    <entity name="Brille24\SyliusTierPricePlugin\Entity\ProductVariant" table="sylius_product_variant">
+    <mapped-superclass name="Brille24\SyliusTierPricePlugin\Entity\ProductVariant" table="sylius_product_variant">
         <one-to-many target-entity="Brille24\SyliusTierPricePlugin\Entity\TierPrice" mapped-by="productVariant" field="tierPrices" orphan-removal="true">
             <cascade>
                 <cascade-all />
@@ -13,5 +13,5 @@
                 <order-by-field name="qty" direction="ASC"/>
             </order-by>
         </one-to-many>
-    </entity>
+    </mapped-superclass>
 </doctrine-mapping>


### PR DESCRIPTION
Because of the way the doctrine metadata in the orm file is constructed (with the use of the entity element) it is not possible to override it easily from another project bundle.

By wrapping the information in a mapped-superclass element, it can be extended, and it tells Doctrine that the entity itself is the final entity, but a extending one. This last is the case for it extends the ProductVariant entity of Sylius self.

Doctrine documentation: https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/inheritance-mapping.html