### PR TITLE
Use Sylius interface as targetEntity to prevent Doctrine proxy problems

### DIFF
--- a/src/Resources/config/doctrine/TierPrice.orm.xml
+++ b/src/Resources/config/doctrine/TierPrice.orm.xml
@@ -16,8 +16,8 @@
         <field name="price" type="integer" />
         <field name="qty" type="integer" />
 
-        <many-to-one target-entity="Sylius\Component\Core\Model\Channel" field="channel" />
+        <many-to-one target-entity="Sylius\Component\Channel\Model\ChannelInterface" field="channel" />
 
-        <many-to-one target-entity="Brille24\SyliusTierPricePlugin\Entity\ProductVariant" field="productVariant" inversed-by="tierPrices"/>
+        <many-to-one target-entity="Sylius\Component\Product\Model\ProductVariantInterface" field="productVariant" inversed-by="tierPrices"/>
     </entity>
 </doctrine-mapping>


### PR DESCRIPTION
I extend `Sylius\Component\Core\Model\Channel` in my app, and Doctrine tries to use the wrong (non-existent) proxy class.