### PR TITLE
Allow a better override

### DIFF
--- a/src/Resources/config/doctrine/TierPrice.orm.xml
+++ b/src/Resources/config/doctrine/TierPrice.orm.xml
@@ -4,7 +4,7 @@
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd"
 >
 
-    <entity
+    <mapped-superclass
             name="Brille24\SyliusTierPricePlugin\Entity\TierPrice"
             repository-class="Brille24\SyliusTierPricePlugin\Repository\TierPriceRepository"
             table="brille24_tierprice"
@@ -19,5 +19,5 @@
         <many-to-one target-entity="Sylius\Component\Channel\Model\ChannelInterface" field="channel" />
 
         <many-to-one target-entity="Sylius\Component\Product\Model\ProductVariantInterface" field="productVariant" inversed-by="tierPrices"/>
-    </entity>
+    </mapped-superclass>
 </doctrine-mapping>


### PR DESCRIPTION
Just making the mapped entity to be a mappedSuperclass allows overriding. The actual entity is managed by SyliusResourceBundle