### PR TITLE
Unlock friends-of-behat/symfony-extension version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "behat/mink-selenium2-driver": "^1.3",
         "friends-of-behat/variadic-extension": "^1.1",
         "friends-of-behat/page-object-extension": "^0.3",
-        "friends-of-behat/symfony-extension": "2.0.4",
+        "friends-of-behat/symfony-extension": "^2.0",
         "lakion/mink-debug-extension": "^1.2.3",
         "phpspec/phpspec": "^5.0",
         "phpstan/phpstan-doctrine": "^0.10",


### PR DESCRIPTION
Unlock the version of the composer friends-of-behat/symfony-extension, to use the latest version of the library.

This is not necessary but maybe "good" to use this plugin with a fresh Sylius installation.