### PR TITLE
Change resource names in line with Symfony 4/5 resource loader

### DIFF
--- a/src/Menu/AdminProductFormMenuListener.php
+++ b/src/Menu/AdminProductFormMenuListener.php
@@ -36,7 +36,7 @@ final class AdminProductFormMenuListener
             return;
         }
 
-        $TIERPRICE_TAB = '@Brille24SyliusTierPricePlugin/Resources/views/Admin/ProductVariant/Tab/_tierprice.html.twig';
+        $TIERPRICE_TAB = '@Brille24SyliusTierPricePlugin/Admin/ProductVariant/Tab/_tierprice.html.twig';
         $menu
             ->addChild('tierprice')
             ->setAttribute('template', $TIERPRICE_TAB)

--- a/src/Menu/AdminProductVariantFormMenuListener.php
+++ b/src/Menu/AdminProductVariantFormMenuListener.php
@@ -32,7 +32,7 @@ final class AdminProductVariantFormMenuListener
     {
         $menu = $event->getMenu();
 
-        $TIERPRICE_TAB = '@Brille24SyliusTierPricePlugin/Resources/views/Admin/ProductVariant/Tab/_tierprice.html.twig';
+        $TIERPRICE_TAB = '@Brille24SyliusTierPricePlugin/Admin/ProductVariant/Tab/_tierprice.html.twig';
         $menu->addChild('tierprice', ['position' => 1])
             ->setAttribute('template', $TIERPRICE_TAB)
             ->setLabel($this->translator->trans('brille24_tier_price.ui.tier_prices'))

--- a/src/Resources/config/services/sonata_events.xml
+++ b/src/Resources/config/services/sonata_events.xml
@@ -4,21 +4,21 @@
                  id="brille24_tier_price.block_event_listener.admin.layout.javascripts"
         >
             <tag name="kernel.event_listener" event="sonata.block.event.sylius.admin.layout.javascripts" method="onBlockEvent" />
-            <argument>@Brille24SyliusTierPricePlugin/Resources/views/Admin/_javascripts.html.twig</argument>
+            <argument>@Brille24SyliusTierPricePlugin/Admin/_javascripts.html.twig</argument>
         </service>
 
         <service class="Sylius\Bundle\UiBundle\Block\BlockEventListener"
                  id="brille24_tier_price.block_event_listener.shop.layout.javascripts.tierprice"
         >
             <tag name="kernel.event_listener" event="sonata.block.event.sylius.shop.layout.javascripts" method="onBlockEvent" />
-            <argument>@Brille24SyliusTierPricePlugin/Resources/views/Shop/_javascripts.html.twig</argument>
+            <argument>@Brille24SyliusTierPricePlugin/Shop/_javascripts.html.twig</argument>
         </service>
 
         <service class="Sylius\Bundle\UiBundle\Block\BlockEventListener"
                  id="brille24_tier_price.sylius.product.show_before_add_to_cart"
         >
             <tag name="kernel.event_listener" event="sonata.block.event.sylius.shop.product.show.before_add_to_cart" method="onBlockEvent" />
-            <argument>@Brille24SyliusTierPricePlugin/Resources/views/Shop/Product/Show/_tier_price_promo.html.twig</argument>
+            <argument>@Brille24SyliusTierPricePlugin/Shop/Product/Show/_tier_price_promo.html.twig</argument>
         </service>
     </services>
 </container>


### PR DESCRIPTION
Symfony 4/5 Resource Loader will now correctly be able to locate template overrides in the expected folder (`/templates`).

#39 