### PR TITLE
Use customer instance from OrderInterface where possible.

### DIFF
--- a/src/Services/OrderPricesRecalculator.php
+++ b/src/Services/OrderPricesRecalculator.php
@@ -53,7 +53,7 @@ final class OrderPricesRecalculator implements OrderProcessorInterface
 
             $item->setUnitPrice($this->productVariantPriceCalculator->calculate(
                 $item->getVariant(),
-                ['channel' => $channel, 'quantity' => $item->getQuantity()]
+                ['channel' => $channel, 'quantity' => $item->getQuantity(), 'customer' => $order->getCustomer()]
             ));
         }
     }

--- a/src/Services/ProductVariantPriceCalculator.php
+++ b/src/Services/ProductVariantPriceCalculator.php
@@ -61,9 +61,15 @@ final class ProductVariantPriceCalculator implements ProductVariantPriceCalculat
             return $this->basePriceCalculator->calculate($productVariant, $context);
         }
 
+        // If customer passed in through $context use that instead of CustomerContextInterface
+        $customer = $this->customerContext->getCustomer();
+        if (array_key_exists('customer', $context)) {
+            $customer = $context['customer'];
+        }
+
         // Find a tier price and return it
         if ($productVariant instanceof TierPriceableInterface) {
-            $tierPrice = $this->tierPriceFinder->find($productVariant, $context['channel'], $context['quantity'], $this->customerContext->getCustomer());
+            $tierPrice = $this->tierPriceFinder->find($productVariant, $context['channel'], $context['quantity'], $customer);
             if ($tierPrice !== null) {
                 return $tierPrice->getPrice();
             }


### PR DESCRIPTION
When using https://github.com/Sylius/AdminOrderCreationPlugin to create orders in the admin system CustomerContextInterface isn't available (specifically it doesn't return a customer entity), meaning group based prices aren't working (tier prices with no group still work however). 

This fixes that issue by having the OrderPricesRecalculator pass in the customer from the order to the ProductVariantPriceCalculator $context parameter, I've left the usage of CustomerContextInterface in ProductVariantPriceCalculator as a fallback for cases where an order may not exist (logged in customer browsing the site for example), but if a customer is passed in through the $context it will always take priority.