### PR TITLE
Channel\Model\ChannelInterface instead of Core\Model\ChannelInterface

### DIFF
--- a/src/Entity/TierPrice.php
+++ b/src/Entity/TierPrice.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Brille24\SyliusTierPricePlugin\Entity;
 
-use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Channel\Model\ChannelInterface;
 use Sylius\Component\Customer\Model\CustomerGroupInterface;
 use Sylius\Component\Resource\Model\ResourceInterface;
 

--- a/src/Entity/TierPriceInterface.php
+++ b/src/Entity/TierPriceInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Brille24\SyliusTierPricePlugin\Entity;
 
-use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Channel\Model\ChannelInterface;
 use Sylius\Component\Customer\Model\CustomerGroupInterface;
 
 /**

--- a/src/Repository/TierPriceRepository.php
+++ b/src/Repository/TierPriceRepository.php
@@ -16,7 +16,7 @@ namespace Brille24\SyliusTierPricePlugin\Repository;
 use Brille24\SyliusTierPricePlugin\Entity\TierPriceInterface;
 use Brille24\SyliusTierPricePlugin\Traits\TierPriceableInterface;
 use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
-use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Channel\Model\ChannelInterface;
 use Sylius\Component\Customer\Model\CustomerGroupInterface;
 
 class TierPriceRepository extends EntityRepository implements TierPriceRepositoryInterface

--- a/src/Repository/TierPriceRepositoryInterface.php
+++ b/src/Repository/TierPriceRepositoryInterface.php
@@ -16,7 +16,7 @@ namespace Brille24\SyliusTierPricePlugin\Repository;
 use Brille24\SyliusTierPricePlugin\Entity\TierPriceInterface;
 use Brille24\SyliusTierPricePlugin\Traits\TierPriceableInterface;
 use Doctrine\Common\Persistence\ObjectRepository;
-use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Channel\Model\ChannelInterface;
 use Sylius\Component\Customer\Model\CustomerGroupInterface;
 
 interface TierPriceRepositoryInterface extends ObjectRepository

--- a/src/Services/TierPriceFinder.php
+++ b/src/Services/TierPriceFinder.php
@@ -16,7 +16,7 @@ namespace Brille24\SyliusTierPricePlugin\Services;
 use Brille24\SyliusTierPricePlugin\Entity\TierPriceInterface;
 use Brille24\SyliusTierPricePlugin\Repository\TierPriceRepositoryInterface;
 use Brille24\SyliusTierPricePlugin\Traits\TierPriceableInterface;
-use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Channel\Model\ChannelInterface;
 use Sylius\Component\Customer\Model\CustomerInterface;
 
 class TierPriceFinder implements TierPriceFinderInterface

--- a/src/Services/TierPriceFinderInterface.php
+++ b/src/Services/TierPriceFinderInterface.php
@@ -15,7 +15,7 @@ namespace Brille24\SyliusTierPricePlugin\Services;
 
 use Brille24\SyliusTierPricePlugin\Entity\TierPriceInterface;
 use Brille24\SyliusTierPricePlugin\Traits\TierPriceableInterface;
-use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Channel\Model\ChannelInterface;
 use Sylius\Component\Customer\Model\CustomerInterface;
 
 interface TierPriceFinderInterface


### PR DESCRIPTION
I created my own `OrderItemQuantityModifier` that implements `Sylius\Component\Order\Modifier\OrderItemQuantityModifierInterface` and use `TierPriceRepository::getSortedTierPrices()` to extract the minimum quantity from returned tier prices.

Since I don't have an actual order to get the channel from, I have to inject `Sylius\Component\Channel\Context\ChannelContextInterface`, but that means there's a small incompatibility there.

`TierPrice.orm.xml` declares the channel relation to the base model, but the TierPrice entity uses the core model of the channel (while for customer group was correct).
```sql
<many-to-one target-entity="Sylius\Component\Channel\Model\ChannelInterface" field="channel">
    <join-column name="channel_id" />
</many-to-one>
<many-to-one target-entity="Sylius\Component\Customer\Model\CustomerGroupInterface" field="customerGroup">
    <join-column name="customer_group_id" />
</many-to-one>
```
```php
use Sylius\Component\Core\Model\ChannelInterface;
use Sylius\Component\Customer\Model\CustomerGroupInterface;
use Sylius\Component\Resource\Model\ResourceInterface;

class TierPrice implements ResourceInterface, TierPriceInterface
```

I made the changes for `TierPrice` entity, `TierPriceRepository` and `TierPriceFinder`. What do you think?