### PR TITLE
Updating Price Calculators to Use New Sylius Interfaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
     "description": "A plugin that allows to add tierprices to Sylius",
     "license": "MIT",
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
 
-        "sylius/sylius": "^1.4"
+        "sylius/sylius": "^1.8"
     },
     "require-dev": {
         "behat/behat": "^3.4",
@@ -19,11 +19,6 @@
         "friends-of-behat/symfony-extension": "^2.0",
         "lakion/mink-debug-extension": "^1.2.3",
         "phpspec/phpspec": "^5.0|^6.1",
-        "phpstan/phpstan-doctrine": "^0.10",
-        "phpstan/phpstan-shim": "^0.10",
-        "phpstan/phpstan-strict-rules": "^0.10.0",
-        "phpstan/phpstan-symfony": "^0.10",
-        "phpstan/phpstan-webmozart-assert": "^0.10",
         "phpunit/phpunit": "^6.5|^8.0",
         "sensiolabs/security-checker": "^5.0",
         "sylius-labs/coding-standard": "^2.0|^3.1",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
          bootstrap="vendor/autoload.php">
     <testsuites>
         <testsuite name="Brille24TestPlugin Test Suite">
-            <directory>src/Brille24</directory>
+            <directory>src/Tests</directory>
         </testsuite>
     </testsuites>
 

--- a/src/Services/OrderPricesRecalculator.php
+++ b/src/Services/OrderPricesRecalculator.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Brille24\SyliusTierPricePlugin\Services;
 
-use Sylius\Component\Core\Calculator\ProductVariantPriceCalculatorInterface;
+use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Order\Model\OrderInterface as BaseOrderInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
@@ -22,14 +22,14 @@ use TypeError;
 final class OrderPricesRecalculator implements OrderProcessorInterface
 {
     /**
-     * @var ProductVariantPriceCalculatorInterface
+     * @var ProductVariantPricesCalculatorInterface
      */
     private $productVariantPriceCalculator;
 
     /**
-     * @param ProductVariantPriceCalculatorInterface $productVariantPriceCalculator
+     * @param ProductVariantPricesCalculatorInterface $productVariantPriceCalculator
      */
-    public function __construct(ProductVariantPriceCalculatorInterface $productVariantPriceCalculator)
+    public function __construct(ProductVariantPricesCalculatorInterface $productVariantPriceCalculator)
     {
         $this->productVariantPriceCalculator = $productVariantPriceCalculator;
     }
@@ -51,7 +51,7 @@ final class OrderPricesRecalculator implements OrderProcessorInterface
                 continue;
             }
 
-            $item->setUnitPrice($this->productVariantPriceCalculator->calculate(
+            $item->setUnitPrice($this->productVariantPriceCalculator->calculateOriginal(
                 $item->getVariant(),
                 ['channel' => $channel, 'quantity' => $item->getQuantity(), 'customer' => $order->getCustomer()]
             ));

--- a/src/Services/ProductVariantPriceCalculator.php
+++ b/src/Services/ProductVariantPriceCalculator.php
@@ -14,14 +14,14 @@ declare(strict_types=1);
 namespace Brille24\SyliusTierPricePlugin\Services;
 
 use Brille24\SyliusTierPricePlugin\Traits\TierPriceableInterface;
-use Sylius\Component\Core\Calculator\ProductVariantPriceCalculatorInterface;
+use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
 use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Customer\Context\CustomerContextInterface;
 
-final class ProductVariantPriceCalculator implements ProductVariantPriceCalculatorInterface
+final class ProductVariantPriceCalculator implements ProductVariantPricesCalculatorInterface
 {
     /**
-     * @var ProductVariantPriceCalculatorInterface
+     * @var ProductVariantPricesCalculatorInterface
      */
     private $basePriceCalculator;
 
@@ -32,13 +32,19 @@ final class ProductVariantPriceCalculator implements ProductVariantPriceCalculat
     private $customerContext;
 
     public function __construct(
-        ProductVariantPriceCalculatorInterface $basePriceCalculator,
+        ProductVariantPricesCalculatorInterface $basePriceCalculator,
         TierPriceFinderInterface $tierPriceFinder,
         CustomerContextInterface $customerContext
     ) {
         $this->basePriceCalculator = $basePriceCalculator;
         $this->tierPriceFinder     = $tierPriceFinder;
         $this->customerContext     = $customerContext;
+    }
+
+    /** {@inheritDoc} */
+    public function calculate(ProductVariantInterface $productVariant, array $context): int
+    {
+        return $this->calculateOriginal($productVariant, $context);
     }
 
     /**
@@ -54,11 +60,11 @@ final class ProductVariantPriceCalculator implements ProductVariantPriceCalculat
      *
      * @return int
      */
-    public function calculate(ProductVariantInterface $productVariant, array $context): int
+    public function calculateOriginal(ProductVariantInterface $productVariant, array $context): int
     {
         // Return the base price if the quantity is not provided
         if (!array_key_exists('quantity', $context)) {
-            return $this->basePriceCalculator->calculate($productVariant, $context);
+            return $this->basePriceCalculator->calculateOriginal($productVariant, $context);
         }
 
         // If customer passed in through $context use that instead of CustomerContextInterface
@@ -76,6 +82,6 @@ final class ProductVariantPriceCalculator implements ProductVariantPriceCalculat
         }
 
         // Return the base price if there are no tier prices
-        return $this->basePriceCalculator->calculate($productVariant, $context);
+        return $this->basePriceCalculator->calculateOriginal($productVariant, $context);
     }
 }

--- a/src/Tests/Services/OrderPricesRecalculatorTest.php
+++ b/src/Tests/Services/OrderPricesRecalculatorTest.php
@@ -16,7 +16,7 @@ namespace Brille24\SyliusTierPricePlugin\Tests\Services;
 use Brille24\SyliusTierPricePlugin\Services\OrderPricesRecalculator;
 use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
-use Sylius\Component\Core\Calculator\ProductVariantPriceCalculatorInterface;
+use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItem;
@@ -35,10 +35,10 @@ class OrderPricesRecalculatorTest extends TestCase
 
     public function setUp(): void
     {
-        $productVariantCalculator = $this->createMock(ProductVariantPriceCalculatorInterface::class);
+        $productVariantCalculator = $this->createMock(ProductVariantPricesCalculatorInterface::class);
         $calculated               = &$this->calculated;
 
-        $productVariantCalculator->method('calculate')->willReturnCallback(
+        $productVariantCalculator->method('calculateOriginal')->willReturnCallback(
             function (ProductVariantInterface $productVariant, array $options) use (&$calculated) {
                 Assert::keyExists($options, 'quantity');
                 Assert::keyExists($options, 'channel');

--- a/src/Tests/Services/ProductVariantPriceCalculatorTest.php
+++ b/src/Tests/Services/ProductVariantPriceCalculatorTest.php
@@ -18,17 +18,17 @@ use Brille24\SyliusTierPricePlugin\Entity\TierPrice;
 use Brille24\SyliusTierPricePlugin\Services\ProductVariantPriceCalculator;
 use Brille24\SyliusTierPricePlugin\Services\TierPriceFinderInterface;
 use PHPUnit\Framework\TestCase;
-use Sylius\Component\Core\Calculator\ProductVariantPriceCalculatorInterface;
+use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductVariant as SyliusProductVariant;
 use Sylius\Component\Customer\Context\CustomerContextInterface;
 
 class ProductVariantPriceCalculatorTest extends TestCase
 {
-    /** @var ProductVariantPriceCalculatorInterface */
+    /** @var ProductVariantPricesCalculatorInterface */
     private $basePriceCalculator;
 
-    /** @var ProductVariantPriceCalculatorInterface */
+    /** @var ProductVariantPricesCalculatorInterface */
     private $priceCalculator;
 
     /** @var TierPriceFinderInterface */
@@ -37,10 +37,10 @@ class ProductVariantPriceCalculatorTest extends TestCase
     /** @var CustomerContextInterface */
     private $customerContext;
 
-    public function setup()
+    public function setUp(): void
     {
-        $this->basePriceCalculator = $this->createMock(ProductVariantPriceCalculatorInterface::class);
-        $this->basePriceCalculator->method('calculate')->willReturn(-1); // To indicate no tier prices
+        $this->basePriceCalculator = $this->createMock(ProductVariantPricesCalculatorInterface::class);
+        $this->basePriceCalculator->method('calculateOriginal')->willReturn(-1); // To indicate no tier prices
 
         $this->tierPriceFinder = $this->createMock(TierPriceFinderInterface::class);
 
@@ -56,7 +56,7 @@ class ProductVariantPriceCalculatorTest extends TestCase
         $testChannel    = $this->createMock(ChannelInterface::class);
 
         //## EXECUTE
-        $price = $this->priceCalculator->calculate($productVariant, ['channel' => $testChannel, 'quantity' => 10]);
+        $price = $this->priceCalculator->calculateOriginal($productVariant, ['channel' => $testChannel, 'quantity' => 10]);
 
         //## CHECK
         $this->assertEquals(-1, $price);
@@ -71,7 +71,7 @@ class ProductVariantPriceCalculatorTest extends TestCase
         $this->tierPriceFinder->method('find')->willReturn(null);
 
         //## EXECUTE
-        $result = $this->priceCalculator->calculate($productVariant, ['channel' => $testChannel, 'quantity' => 10]);
+        $result = $this->priceCalculator->calculateOriginal($productVariant, ['channel' => $testChannel, 'quantity' => 10]);
 
         //## CHECK
         $this->assertEquals(-1, $result);
@@ -86,7 +86,7 @@ class ProductVariantPriceCalculatorTest extends TestCase
         $this->tierPriceFinder->method('find')->willReturn(new TierPrice(2, 2));
 
         //## EXECUTE
-        $result = $this->priceCalculator->calculate($productVariant, ['channel' => $testChannel, 'quantity' => 10]);
+        $result = $this->priceCalculator->calculateOriginal($productVariant, ['channel' => $testChannel, 'quantity' => 10]);
 
         //## CHECK
         $this->assertEquals(2, $result);


### PR DESCRIPTION
Version 1.8 of Sylius changed the price calculator interface names and broke this package. This PR makes updates using the new interface names and implementations.