### PR TITLE
Updates templates references

### DIFF
--- a/src/Resources/views/Admin/_javascripts.html.twig
+++ b/src/Resources/views/Admin/_javascripts.html.twig
@@ -1,3 +1,3 @@
 {# Including javascript #}
-{% include 'SyliusUiBundle::_javascripts.html.twig' with {path: 'bundles/brille24syliustierpriceplugin/js/tierPrices/itemCollectionRender.js'} %}
-{% include 'SyliusUiBundle::_javascripts.html.twig' with {path: 'bundles/brille24syliustierpriceplugin/js/jQueryElementSort.js'} %}
+{% include '@SyliusUi/_javascripts.html.twig' with {path: 'bundles/brille24syliustierpriceplugin/js/tierPrices/itemCollectionRender.js'} %}
+{% include '@SyliusUi/_javascripts.html.twig' with {path: 'bundles/brille24syliustierpriceplugin/js/jQueryElementSort.js'} %}


### PR DESCRIPTION
Bundle notation has been removed in SyliusTheme 2: https://github.com/Sylius/SyliusThemeBundle/blob/master/UPGRADE.md#referencing-templates