### PR TITLE
Fix doctrine attribute error

### DIFF
--- a/src/Traits/TierPriceableTrait.php
+++ b/src/Traits/TierPriceableTrait.php
@@ -40,7 +40,7 @@ trait TierPriceableTrait
     }
 
     /** @var ArrayCollection<int, TierPriceInterface> */
-    #[OneToMany(TierPrice::class, mappedBy: "productVariant", orphanRemoval: true, cascade: ['all'])]
+    #[OneToMany(mappedBy: "productVariant", targetEntity: TierPrice::class, cascade: ['all'], orphanRemoval: true)]
     #[OrderBy(['customerGroup' => 'ASC', 'qty' => 'ASC'])]
     protected $tierPrices;
 


### PR DESCRIPTION
`mappedBy` is by default the first parameter passed to the `OneToMany` attribute. Therefore, putting an unnamed parameter first causes issues.

> Named parameter $mappedBy overwrites previous argument

Edit:
This only appears to be an issue in sub 3.0 versions. But this fix will also continue to work in 3.x