### PR TITLE
fix: remove PrependDoctrineMigrationsTrait from bundles extension

### DIFF
--- a/src/DependencyInjection/Brille24SyliusTierPriceExtension.php
+++ b/src/DependencyInjection/Brille24SyliusTierPriceExtension.php
@@ -13,18 +13,14 @@ declare(strict_types=1);
 
 namespace Brille24\SyliusTierPricePlugin\DependencyInjection;
 
-use Sylius\Bundle\CoreBundle\DependencyInjection\PrependDoctrineMigrationsTrait;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
-use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 
-final class Brille24SyliusTierPriceExtension extends Extension implements PrependExtensionInterface
+final class Brille24SyliusTierPriceExtension extends Extension
 {
-    use PrependDoctrineMigrationsTrait;
-
     /** @inheritdoc */
     public function load(array $configs, ContainerBuilder $container): void
     {
@@ -32,26 +28,6 @@ final class Brille24SyliusTierPriceExtension extends Extension implements Prepen
 
         $loder = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../../config'));
         $loder->load('services.php');
-    }
-
-    public function prepend(ContainerBuilder $container): void
-    {
-        $this->prependDoctrineMigrations($container);
-    }
-
-    protected function getMigrationsNamespace(): string
-    {
-        return 'Brille24\SyliusTierPricePlugin\Migrations';
-    }
-
-    protected function getMigrationsDirectory(): string
-    {
-        return '@Brille24SyliusTierPricePlugin/Migrations';
-    }
-
-    protected function getNamespacesOfMigrationsExecutedBefore(): array
-    {
-        return ['Sylius\Bundle\CoreBundle\Migrations'];
     }
 
     public function getConfiguration(array $config, ContainerBuilder $container): ConfigurationInterface


### PR DESCRIPTION
After installing the v4.0.0 of the bundle and trying to generate a new migration I run into this error:

```sh
/var/www $ php bin/console doctrine:m:diff
Please choose a namespace (defaults to the first one)
  [0] App
  [1] Brille24\SyliusTierPricePlugin\Migrations
  [2] Sylius\PayPalPlugin\Migrations
  [3] Sylius\Bundle\CoreBundle\Migrations
 > 0
 You have selected the "App" namespace

In InvalidDirectory.php line 15:
                                                                                                                                 
  Cannot load migrations from "/var/www/vendor/brille24/sylius-tierprice-plugin/Migrations" because it is not a valid directory  
                                                                                                                                 

doctrine:migrations:diff [--configuration CONFIGURATION] [--em EM] [--conn CONN] [--namespace NAMESPACE] [--filter-expression FILTER-EXPRESSION] [--formatted] [--line-length LINE-LENGTH] [--check-database-platform [CHECK-DATABASE-PLATFORM]] [--allow-empty-diff] [--from-empty-schema]
```

Looking at the bundles code, there are no migrations, therefore I removed that part of the Extensions code. 